### PR TITLE
fix: lint errors

### DIFF
--- a/bucketeer/src/main/java/jp/bucketeer/sdk/ext/CursorExt.kt
+++ b/bucketeer/src/main/java/jp/bucketeer/sdk/ext/CursorExt.kt
@@ -8,14 +8,13 @@ internal fun Cursor.asSequence(): Sequence<Cursor> {
 
 // TODO add Cursor.get(Int, Long, Double, ...)
 internal fun Cursor.getString(name: String): String {
-  return getString(getColumnIndex(name)) ?: throw IllegalStateException()
+  return getString(getColumnIndexOrThrow(name))
 }
 
 internal fun Cursor.getBlob(name: String): ByteArray {
-  return getBlob(getColumnIndex(name)) ?: throw IllegalStateException()
+  return getBlob(getColumnIndexOrThrow(name))
 }
 
 internal fun Cursor.getInt(name: String): Int {
-  return getInt(getColumnIndex(name))
+  return getInt(getColumnIndexOrThrow(name))
 }
-


### PR DESCRIPTION
The problem is that cursor.getColumnIndex() can return -1.

Source: https://stackoverflow.com/a/69979270

```
  Errors found:
  
  /Users/a13778/workspace/src/github.com/ca-dp/bucketeer-android-sdk/bucketeer/src/main/java/jp/bucketeer/sdk/ext/CursorExt.kt:11: Error: Value must be ≥ 0 [Range]
    return getString(getColumnIndex(name)) ?: throw IllegalStateException()
                     ~~~~~~~~~~~~~~~~~~~~
  /Users/a13778/workspace/src/github.com/ca-dp/bucketeer-android-sdk/bucketeer/src/main/java/jp/bucketeer/sdk/ext/CursorExt.kt:15: Error: Value must be ≥ 0 [Range]
    return getBlob(getColumnIndex(name)) ?: throw IllegalStateException()
                   ~~~~~~~~~~~~~~~~~~~~
  /Users/a13778/workspace/src/github.com/ca-dp/bucketeer-android-sdk/bucketeer/src/main/java/jp/bucketeer/sdk/ext/CursorExt.kt:19: Error: Value must be ≥ 0 [Range]
    return getInt(getColumnIndex(name))
                  ~~~~~~~~~~~~~~~~~~~~

```