### PR TITLE
remove in-memory cache in EventInteractor

### DIFF
--- a/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -136,7 +136,6 @@ internal class BKTClientImpl(
 
   private fun refreshCache() {
     component.evaluationInteractor.refreshCache(component.userHolder.userId)
-    component.eventInteractor.refreshCache()
   }
 
   internal fun initializeInternal(timeoutMillis: Long): Future<BKTException?> {

--- a/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -1,6 +1,5 @@
 package io.bucketeer.sdk.android.internal.event
 
-import androidx.annotation.VisibleForTesting
 import io.bucketeer.sdk.android.BKTException
 import io.bucketeer.sdk.android.internal.Clock
 import io.bucketeer.sdk.android.internal.IdGenerator
@@ -11,7 +10,6 @@ import io.bucketeer.sdk.android.internal.model.Event
 import io.bucketeer.sdk.android.internal.model.User
 import io.bucketeer.sdk.android.internal.remote.ApiClient
 import io.bucketeer.sdk.android.internal.remote.RegisterEventsResult
-import java.util.concurrent.atomic.AtomicReference
 
 internal class EventInteractor(
   private val eventsMaxBatchQueueCount: Int,
@@ -20,9 +18,6 @@ internal class EventInteractor(
   private val clock: Clock,
   private val idGenerator: IdGenerator,
 ) {
-
-  @VisibleForTesting
-  internal val events: AtomicReference<List<Event>> = AtomicReference(emptyList())
 
   private var eventUpdateListener: EventUpdateListener? = null
 
@@ -90,7 +85,7 @@ internal class EventInteractor(
   }
 
   fun sendEvents(force: Boolean = false): SendEventsResult {
-    val current = events.get()
+    val current = eventDao.getEvents()
 
     if (current.isEmpty()) {
       logd { "no events to register" }
@@ -130,13 +125,8 @@ internal class EventInteractor(
     }
   }
 
-  fun refreshCache() {
-    events.set(eventDao.getEvents())
-  }
-
   private fun updateEventsAndNotify() {
-    refreshCache()
-    eventUpdateListener?.onUpdate(this.events.get())
+    eventUpdateListener?.onUpdate(eventDao.getEvents())
   }
 
   fun interface EventUpdateListener {

--- a/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/internal/user/UserHolder.kt
+++ b/bucketeer2/src/main/kotlin/io/bucketeer/sdk/android/internal/user/UserHolder.kt
@@ -3,7 +3,7 @@ package io.bucketeer.sdk.android.internal.user
 import io.bucketeer.sdk.android.BKTUser
 import io.bucketeer.sdk.android.internal.model.User
 
-class UserHolder(
+internal class UserHolder(
   private var user: User,
 ) {
   val userId: String = user.id

--- a/bucketeer2/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer2/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -102,14 +102,6 @@ class BKTClientImplTest {
 
     Thread.sleep(100)
 
-    val memoryEvents = client.component.eventInteractor.events.get()
-    assertThat(memoryEvents).hasSize(2)
-    assertGetEvaluationLatencyMetricsEvent(memoryEvents[0], mapOf("tag" to config.featureTag))
-    assertGetEvaluationSizeMetricsEvent(
-      memoryEvents[1],
-      MetricsEventData.GetEvaluationSizeMetricsEvent(mapOf("tag" to config.featureTag), 734),
-    )
-
     val dbEvents = client.component.dataModule.eventDao.getEvents()
     assertThat(dbEvents).hasSize(2)
     assertGetEvaluationLatencyMetricsEvent(dbEvents[0], mapOf("tag" to config.featureTag))
@@ -161,12 +153,6 @@ class BKTClientImplTest {
     Thread.sleep(100)
 
     // timeout event should be saved
-    val memoryEvents = client.component.eventInteractor.events.get()
-    assertTimeoutErrorCountMetricsEvent(
-      memoryEvents[0],
-      MetricsEventData.TimeoutErrorCountMetricsEvent(config.featureTag),
-    )
-
     val dbEvents = client.component.dataModule.eventDao.getEvents()
     assertThat(dbEvents).hasSize(1)
     assertTimeoutErrorCountMetricsEvent(


### PR DESCRIPTION
After reconsidering a bit, I realized that `EventInteractor` does not need an in-memory cache of events, as every call to EventInteractor is made from an Executor and that means we can safely access DB.